### PR TITLE
Feature/configmaps metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # thoth-metrics
-# Copyright(C) 2018, 2019 Christoph Görn
+# Copyright(C) 2018, 2019 Christoph Görn, Francesco Murdaca
 #
 # This program is free software: you can redistribute it and / or modify
 # it under the terms of the GNU General Public License as published by
@@ -42,6 +42,7 @@ from thoth.metrics_exporter.jobs import (
     get_user_unique_run_software_environment_count,
     get_unique_build_software_environment_count,
     get_thoth_graph_sync_jobs,
+    get_configmaps_per_namespace_per_operator
 )
 
 
@@ -87,6 +88,7 @@ async def metrics(req, resp):
     def update_openshift_metrics():
         _LOGGER.debug("updating OpenShift metrics")
         get_thoth_graph_sync_jobs()
+        get_configmaps_per_namespace_per_operator()
 
     update_dgraph_metrics()
     update_openshift_metrics()

--- a/openshift/deployment-template.yaml
+++ b/openshift/deployment-template.yaml
@@ -82,6 +82,14 @@ objects:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: "THOTH_MIDDLETIER_NAMESPACE"
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: middletier-namespace
+                - name: "THOTH_BACKEND_NAMESPACE"
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: backend-namespace
                 - name: "RSYSLOG_HOST"
                   valueFrom:
                     configMapKeyRef:

--- a/thoth/metrics_exporter/__init__.py
+++ b/thoth/metrics_exporter/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # thoth-metrics
-# Copyright(C) 2018, 2019 Christoph Görn
+# Copyright(C) 2018, 2019 Christoph Görn, Francesco Murdaca
 #
 # This program is free software: you can redistribute it and / or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""This is a Promotheus Metrics exporter for Thoth."""
+"""This is a Prometheus Metrics exporter for Thoth."""
 
 
 from prometheus_client import Gauge, Summary
@@ -38,7 +38,14 @@ metrics_exporter_info.labels(__version__).inc()
 
 # SERVICE METRICS
 # Solver Jobs
-jobs_sync_status = Gauge("thoth_graph_sync_jobs_status", "Graph Sync Jobs status overview.", ["job_type", "job_status"])
+jobs_sync_status = Gauge(
+    "thoth_graph_sync_jobs_status", "Graph Sync Jobs status overview.", ["job_type", "job_status", "namespace"]
+)
+
+# ConfigMaps
+config_maps_number = Gauge(
+    "thoth_config_maps_number", "Thoth ConfigMaps per namespace per label.", ["namespace", "label"]
+)
 
 
 # CONTENT METRICS
@@ -92,5 +99,5 @@ graphdb_total_build_software_environment = Gauge(
     "thoth_graphdb_total_build_software_environment", "Total number of unique software environment for build", []
 )
 
-# Graph Metrics Availability
+# Graph connection availability
 graphdb_connection_error_status = Gauge("thoth_graphdb_connection_issues", "Connection error status", [])

--- a/thoth/metrics_exporter/jobs.py
+++ b/thoth/metrics_exporter/jobs.py
@@ -41,9 +41,8 @@ init_logging()
 _LOGGER = logging.getLogger("thoth.metrics_exporter.jobs")
 
 
-def countGraphSyncJobStatus(JobListItems: dict) -> (int, int, int):
+def countGraphSyncJobStatus(job_list_items: list) -> dict:
     """Count the number of created, active, failed, succeeded, pending graph-sync Jobs."""
-    graph_sync_jobs_status = {}
     graph_sync_job_status = ["created", "active", "failed", "succeeded", "pending"]
     graph_sync_job_types = [
         "solver",
@@ -55,12 +54,14 @@ def countGraphSyncJobStatus(JobListItems: dict) -> (int, int, int):
     ]
 
     # Initialize
-    for graph_sync_job_type in graph_sync_job_types:
-        graph_sync_jobs_status[f"graph-sync-{graph_sync_job_type}"] = {}
+    graph_sync_jobs_status = dict.fromkeys(
+        [f"graph-sync-{graph_sync_job_type}" for graph_sync_job_type in graph_sync_job_types], {}
+    )
+    for graph_sync_job_type in graph_sync_jobs_status.keys():
         for job_s in graph_sync_job_status:
-            graph_sync_jobs_status[f"graph-sync-{graph_sync_job_type}"][job_s] = 0
+            graph_sync_jobs_status[graph_sync_job_type][job_s] = 0
 
-    for item in JobListItems:
+    for item in job_list_items:
         for graph_sync_job_type in graph_sync_job_types:
             if graph_sync_job_type in item["metadata"]["name"]:
                 job_type = f"graph-sync-{graph_sync_job_type}"
@@ -74,24 +75,73 @@ def countGraphSyncJobStatus(JobListItems: dict) -> (int, int, int):
             graph_sync_jobs_status[job_type]["failed"] += 1
         elif "active" in item["status"].keys():
             graph_sync_jobs_status[job_type]["active"] += 1
-        else:
+        elif "pending" in item["status"].keys():
             graph_sync_jobs_status[job_type]["pending"] += 1
+        else:
+            _LOGGER.error("Unknown job status %r", item["status"])
 
     return graph_sync_jobs_status
 
 
 def get_thoth_graph_sync_jobs():
     """Get the total number of graph-sync Jobs per category with corresponding status."""
-    namespace = os.getenv("MY_NAMESPACE")
+    namespaces = []
+    namespaces.append(os.getenv("MY_NAMESPACE"))
+
+    if os.getenv("THOTH_MIDDLETIER_NAMESPACE"):
+        namespaces.append(os.getenv("THOTH_MIDDLETIER_NAMESPACE"))
+    else:
+        _LOGGER.warning("Thoth namespace variable not provided for %r", "THOTH_MIDDLETIER_NAMESPACE")
+
+    if os.getenv("THOTH_BACKEND_NAMESPACE"):
+        namespaces.append(os.getenv("THOTH_BACKEND_NAMESPACE"))
+    else:
+        _LOGGER.warning("Thoth namespace variable not provided for %r", "THOTH_BACKEND_NAMESPACE")
+
     openshift = OpenShift()
-    response = openshift.get_jobs(label_selector="component=graph-sync", namespace=namespace)
+    for namespace in list(set(namespaces)):
+        _LOGGER.info("Evaluating jobs metrics for Thoth namespace: %r", namespace)
+        response = openshift.get_jobs(label_selector="component=graph-sync", namespace=namespace)
 
-    jobs_status = countGraphSyncJobStatus(response["items"])
-    for j_type, j_statuses in jobs_status.items():
-        for j_status, j_counts in j_statuses.items():
-            jobs_sync_status.labels(j_type, j_status).set(j_counts)
+        jobs_status = countGraphSyncJobStatus(response["items"])
+        for j_type, j_statuses in jobs_status.items():
+            for j_status, j_counts in j_statuses.items():
+                jobs_sync_status.labels(j_type, j_status, namespace).set(j_counts)
+        _LOGGER.debug("thoth_graph_sync_jobs=%r", jobs_status)
 
-    _LOGGER.debug("thoth_graph_sync_jobs=%r", jobs_status)
+
+def count_configmaps(config_map_list_items: list) -> int:
+    """Count the number of ConfigMaps for a certain label in a specific namespace."""
+    return len(config_map_list_items["items"])
+
+
+def get_configmaps_per_namespace_per_operator():
+    """Get the total number of configmaps in the namespace from operators."""
+    namespaces = []
+    namespaces.append(os.getenv("MY_NAMESPACE"))
+
+    if os.getenv("THOTH_MIDDLETIER_NAMESPACE"):
+        namespaces.append(os.getenv("THOTH_MIDDLETIER_NAMESPACE"))
+    else:
+        _LOGGER.warning("Thoth namespace variable not provided for %r", "THOTH_MIDDLETIER_NAMESPACE")
+
+    if os.getenv("THOTH_BACKEND_NAMESPACE"):
+        namespaces.append(os.getenv("THOTH_BACKEND_NAMESPACE"))
+    else:
+        _LOGGER.warning("Thoth namespace variable not provided for %r", "THOTH_BACKEND_NAMESPACE")
+
+    openshift = OpenShift()
+    operators = ["operator=workload", "operator=graph-sync"]
+    for namespace in list(set(namespaces)):
+        _LOGGER.info("Evaluating configmaps metrics for Thoth namespace: %r", namespace)
+
+        for operator in operators:
+            config_maps_items = openshift.get_configmaps(namespace=namespace, label_selector=operator)
+            number_configmaps = count_configmaps(config_maps_items)
+            config_maps_number.labels(namespace, operator).set(number_configmaps)
+            _LOGGER.debug(
+                "thoth_config_maps_number=%r, in namespace=%r for label=%r", number_configmaps, namespace, operator
+            )
 
 
 def get_tot_nodes_count():
@@ -101,13 +151,10 @@ def get_tot_nodes_count():
         graph_db.connect()
 
         v_total = graph_db.get_number_of_each_vertex_in_graph()
-
         graphdb_total_nodes_instances.set(sum([count_vertex for count_vertex in v_total.values()]))
-
         graphdb_connection_error_status.set(0)
 
         _LOGGER.debug("graphdb_connection_error_status=%r", 0)
-
         _LOGGER.debug("graphdb_total_nodes_instances=%r", sum([count_vertex for count_vertex in v_total.values()]))
 
     except Exception as excptn:
@@ -127,7 +174,6 @@ def get_tot_nodes_for_each_entity_count():
             graphdb_total_instances_per_node.labels(v_label).set(v_instances_count)
 
         graphdb_connection_error_status.set(0)
-
         _LOGGER.debug("graphdb_connection_error_status=%r", 0)
 
         _LOGGER.debug("graphdb_total_instances_per_node=%r", v_instances_total)
@@ -157,7 +203,6 @@ def get_python_packages_solver_error_count():
         )
 
         graphdb_connection_error_status.set(0)
-
         _LOGGER.debug("graphdb_connection_error_status=%r", 0)
 
         _LOGGER.debug(
@@ -186,10 +231,9 @@ def get_unique_python_packages_count():
         graph_db.connect()
 
         total_unique_python_packages = len(graph_db.get_python_packages())
-
         graphdb_total_unique_python_packages.set(total_unique_python_packages)
-        graphdb_connection_error_status.set(0)
 
+        graphdb_connection_error_status.set(0)
         _LOGGER.debug("graphdb_connection_error_status=%r", 0)
 
         _LOGGER.debug("graphdb_total_unique_python_packages=%r", len(graph_db.get_python_packages()))
@@ -206,10 +250,9 @@ def get_unique_run_software_environment_count():
         graph_db.connect()
 
         thoth_graphdb_total_run_software_environment = len(set(graph_db.run_software_environment_listing()))
-
         graphdb_total_run_software_environment.set(thoth_graphdb_total_run_software_environment)
-        graphdb_connection_error_status.set(0)
 
+        graphdb_connection_error_status.set(0)
         _LOGGER.debug("graphdb_connection_error_status=%r", 0)
 
         _LOGGER.debug("graphdb_total_unique_run_software_environment=%r", thoth_graphdb_total_run_software_environment)
@@ -230,8 +273,8 @@ def get_user_unique_run_software_environment_count():
         )
 
         graphdb_total_user_run_software_environment.set(thoth_graphdb_total_user_run_software_environment)
-        graphdb_connection_error_status.set(0)
 
+        graphdb_connection_error_status.set(0)
         _LOGGER.debug("graphdb_connection_error_status=%r", 0)
 
         _LOGGER.debug(
@@ -252,8 +295,8 @@ def get_unique_build_software_environment_count():
         thoth_graphdb_total_build_software_environment = len(set(graph_db.build_software_environment_listing()))
 
         graphdb_total_build_software_environment.set(thoth_graphdb_total_build_software_environment)
-        graphdb_connection_error_status.set(0)
 
+        graphdb_connection_error_status.set(0)
         _LOGGER.debug("graphdb_connection_error_status=%r", 0)
 
         _LOGGER.debug(


### PR DESCRIPTION
Depends-On: https://github.com/thoth-station/common/pull/413

We can collect metrics from a namespace regarding the number of ConfigMaps existing for a certain label.

- Added two new environment variables, so that metrics-exporter can collect metrics in different namespaces
- Created new metrics for the number of ConfigMaps in certain namespace
- Created new functions to collect those metrics and making them available for Prometheus
- Created namespace label for job status 

