### PR TITLE
Provide readiness and liveness probes

### DIFF
--- a/openshift/deployment-template.yaml
+++ b/openshift/deployment-template.yaml
@@ -128,6 +128,22 @@ objects:
                 limits:
                   memory: "768Mi"
                   cpu: "2"
+              readinessProbe:
+                httpGet:
+                  path: "/metrics"
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                timeoutSeconds: 10
+              livenessProbe:
+                httpGet:
+                  path: "/metrics"
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                timeoutSeconds: 10
           volumes:
             - name: dgraph-tls-secrets
               secret:


### PR DESCRIPTION
This should help removing "gaps" we see in graph during rolling deployments in
the cluster.