### PR TITLE
changed sa from thoth-ops to metrics-exporter

### DIFF
--- a/openshift/deployment-template.yaml
+++ b/openshift/deployment-template.yaml
@@ -74,7 +74,7 @@ objects:
           labels:
             service: metrics-exporter
         spec:
-          serviceAccountName: "thoth-ops"
+          serviceAccountName: metrics-exporter
           containers:
             - name: "metrics-exporter"
               env:


### PR DESCRIPTION
changed sa from thoth-ops to metrics-exporter
 - To maintain consistency the service account has been modified to metrics-exporter.
 -  Already updated in **stage** environment.

Rolebinding needed:
- thoth-frontend-stage
- thoth-middletier-stage
- thoth-backend-stage
- thoth-amun-api-stage
- thoth-amun-inspection-stage
 
Already updated in **stage** environment.

Related-to: https://github.com/thoth-station/thoth-ops/issues/68

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>