### PR TITLE
Added metrics to check inspections in Ceph per identifier (if any)

### DIFF
--- a/thoth/metrics_exporter/metrics.py
+++ b/thoth/metrics_exporter/metrics.py
@@ -42,8 +42,11 @@ config_maps_number = Gauge(
 )
 
 # Ceph results stored
-ceph_results_number = Gauge(
-    "thoth_ceph_results_number", "Thoth Ceph result per type.", ["result_type"]
+ceph_results_number = Gauge("thoth_ceph_results_number", "Thoth Ceph result per type.", ["result_type"])
+
+# Inspection results stored in Ceph per identifier
+inspection_results_ceph = Gauge(
+    "thoth_inspection_results_ceph", "Thoth Inspections result in Ceph per identifier.", ["identifier"]
 )
 
 # CONTENT METRICS


### PR DESCRIPTION
Added metrics to check inspections in Ceph per identifier (if any).

Example:
```
# HELP thoth_inspection_results_ceph Thoth Inspections result in Ceph per identifier. # TYPE thoth_inspection_results_ceph gauge 
- thoth_inspection_results_ceph{identifier="without_identifier"} 2264.0
- thoth_inspection_results_ceph{identifier="20k_test"} 300.0
- thoth_inspection_results_ceph{identifier="dataset"} 5678.0
- thoth_inspection_results_ceph{identifier="last_test"} 1.0
- thoth_inspection_results_ceph{identifier="test_name"} 1.0 #
```
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>