### PR TITLE
Remove unused debug variable

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -40,7 +40,6 @@ init_logging()
 _LOGGER = logging.getLogger("thoth.metrics_exporter")
 _LOGGER.info(f"Thoth Metrics Exporter v{__version__}")
 
-_DEBUG = os.getenv("METRICS_EXPORTER_DEBUG", False)
 _UPDATE_INTERVAL_SECONDS = int(os.getenv("THOTH_METRICS_EXPORTER_UPDATE_INTERVAL", 20))
 _JOBS_RUN = 0
 _INITIALIZED = False


### PR DESCRIPTION
Debug mode can be turned on by setting environment variable `THOTH_LOG_METRICS__EXPORTER` to `DEBUG`.