### PR TITLE
Created metrics to avoid 'race conditions'

### DIFF
--- a/thoth/metrics_exporter/jobs/solver.py
+++ b/thoth/metrics_exporter/jobs/solver.py
@@ -69,6 +69,8 @@ class SolverMetrics(MetricsBase):
         graph_db = GraphDatabase()
         graph_db.connect()
 
+        total_python_packages_solved = graph_db.get_solved_python_packages_count_all(distinct=True)
+
         total_python_packages_solver_error = graph_db.get_error_solved_python_package_versions_count_all(distinct=True)
         total_python_packages_solver_error_unparseable = graph_db.get_error_solved_python_package_versions_count_all(
             unparseable=True, distinct=True
@@ -77,6 +79,11 @@ class SolverMetrics(MetricsBase):
             unsolvable=True, distinct=True
         )
 
+        total_python_packages_solved_with_no_error = total_python_packages_solved - total_python_packages_solver_error
+
+        metrics.graphdb_total_python_packages_solved_with_no_error.set(
+            total_python_packages_solved_with_no_error
+        )
         metrics.graphdb_total_python_packages_with_solver_error_unparseable.set(
             total_python_packages_solver_error_unparseable
         )
@@ -84,6 +91,11 @@ class SolverMetrics(MetricsBase):
             total_python_packages_solver_error_unsolvable
         )
         metrics.graphdb_total_python_packages_with_solver_error.set(total_python_packages_solver_error)
+
+        _LOGGER.debug(
+            "graphdb_total_python_packages_solved_with_no_error=%r",
+            total_python_packages_solved_with_no_error,
+        )
 
         _LOGGER.debug("graphdb_total_python_packages_with_solver_error=%r", total_python_packages_solver_error)
 

--- a/thoth/metrics_exporter/metrics.py
+++ b/thoth/metrics_exporter/metrics.py
@@ -148,6 +148,11 @@ graphdb_total_number_solvers = Gauge(
     "Total number of solvers in Thoth Infra namespace.",
     [],
 )
+graphdb_total_python_packages_solved_with_no_error = Gauge(
+    "thoth_graphdb_total_python_packages_with_no_error",
+    "Total number of python packages solved with no error.",
+    [],
+)
 graphdb_total_python_packages_with_solver_error = Gauge(
     "thoth_graphdb_total_python_packages_with_solver_error",
     "Total number of python packages with solver error True.",


### PR DESCRIPTION
As @fridex pointed out, in Grafana the metric that counts `total number of solved packages with no error` went below 0. This is because that metric is evaluated as difference between two metrics which are evaluated randomly. In certain circumstances, like when lot of solver are run, the metric subtracted can be evaluated before the other and therefore can have a value higher. The stability is reached after solver finished and a new equilibrium is reached. 

This PR evaluate this metric directly in 'metrics-exporter', therfore it avoid that situation, because both metrics that make `total number of solved packages with no error` are evaluated at the same time.

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>