### PR TITLE
Give metrics-exporter more time to boot

### DIFF
--- a/openshift/deployment-template.yaml
+++ b/openshift/deployment-template.yaml
@@ -207,7 +207,7 @@ objects:
                   path: "/metrics"
                   port: 8080
                   scheme: HTTP
-                initialDelaySeconds: 10
+                initialDelaySeconds: 120
                 periodSeconds: 10
                 timeoutSeconds: 10
               livenessProbe:
@@ -215,7 +215,7 @@ objects:
                   path: "/metrics"
                   port: 8080
                   scheme: HTTP
-                initialDelaySeconds: 10
+                initialDelaySeconds: 180
                 periodSeconds: 10
                 timeoutSeconds: 10
       test: false


### PR DESCRIPTION
To guarantee smooth metrics on rolling deployments, metrics-exporter reports
503 until all the metrics are obtained. As we have a lot of data in the
cluster, metrics-exporter fails to obtain metrics in the given time and
deployment fails.