### PR TITLE
Increment metrics evaluation counter each time a metrics method is called

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -61,11 +61,12 @@ def func_wrapper(func: typing.Callable) -> None:
     global _JOBS_RUN
     global _INITIALIZED
 
-    func()
-
-    if not _INITIALIZED:
-        # Increment/keep track only until we are not initialized.
-        _JOBS_RUN += 1
+    try:
+        func()
+    finally:
+        if not _INITIALIZED:
+            # Increment/keep track only until we are not initialized.
+            _JOBS_RUN += 1
 
 
 class _Config:


### PR DESCRIPTION
If there is raised an exception in any metrics method, the increment is not
performed and service does not become available.