### PR TITLE
Fix graph connection pool handling

### DIFF
--- a/thoth/metrics_exporter/jobs/adviser.py
+++ b/thoth/metrics_exporter/jobs/adviser.py
@@ -36,7 +36,7 @@ class AdviserMetrics(MetricsBase):
     @register_metric_job
     def get_advised_python_software_stack_count(cls) -> None:
         """Get the total number of Advised Python Software Stacks in Thoth Knowledge Graph."""
-        thoth_graphdb_total_advised_software_stacks = cls.GRAPH.get_python_software_stack_count_all(
+        thoth_graphdb_total_advised_software_stacks = cls.graph().get_python_software_stack_count_all(
             software_stack_type=SoftwareStackTypeEnum.ADVISED.value
         )
         metrics.graphdb_advised_software_stacks_records.set(thoth_graphdb_total_advised_software_stacks)

--- a/thoth/metrics_exporter/jobs/base.py
+++ b/thoth/metrics_exporter/jobs/base.py
@@ -25,6 +25,7 @@ from typing import Callable
 from decorator import decorator
 import inspect
 import textwrap
+from typing import Any
 
 from thoth.storages import GraphDatabase
 
@@ -71,13 +72,16 @@ class _MetricsType(type):
 class MetricsBase(metaclass=_MetricsType):
     """A base class for grouping metrics."""
 
-    GRAPH = GraphDatabase()
+    _GRAPH = None
 
     def __init__(self) -> None:
         """Do not instantiate this class."""
         raise NotImplemented
 
+    @classmethod
+    def graph(cls):
+        if not cls._GRAPH:
+            cls._GRAPH = GraphDatabase()
+            cls._GRAPH.connect()
 
-# Maintain one connection per metrics-exporter.
-if not MetricsBase.GRAPH.is_connected():
-    MetricsBase.GRAPH.connect()
+        return cls._GRAPH

--- a/thoth/metrics_exporter/jobs/db.py
+++ b/thoth/metrics_exporter/jobs/db.py
@@ -36,7 +36,7 @@ class DBMetrics(MetricsBase):
     def get_graphdb_connection_error_status(cls) -> None:
         """Raise a flag if there is an error connecting to database."""
         try:
-            cls.GRAPH._engine.execute("SELECT 1")
+            cls.graph()._engine.execute("SELECT 1")
         except Exception as excptn:
             metrics.graphdb_connection_error_status.set(0)
             _LOGGER.exception(excptn)
@@ -47,9 +47,9 @@ class DBMetrics(MetricsBase):
     @register_metric_job
     def get_tot_records_count(cls) -> None:
         """Get the total number of Records in Thoth Knowledge Graph."""
-        main_models_record_count = sum(cls.GRAPH.get_main_table_count().values())
-        relation_models_record_count = sum(cls.GRAPH.get_relation_table_count().values())
-        performance_models_record_count = sum(cls.GRAPH.get_performance_table_count().values())
+        main_models_record_count = sum(cls.graph().get_main_table_count().values())
+        relation_models_record_count = sum(cls.graph().get_relation_table_count().values())
+        performance_models_record_count = sum(cls.graph().get_performance_table_count().values())
 
         total_records_count = main_models_record_count + relation_models_record_count + performance_models_record_count
         metrics.graphdb_total_records.set(total_records_count)
@@ -60,7 +60,7 @@ class DBMetrics(MetricsBase):
     @register_metric_job
     def get_tot_main_records_count(cls) -> None:
         """Get the total number of Records for Main Tables in Thoth Knowledge Graph."""
-        main_models_records = cls.GRAPH.get_main_table_count()
+        main_models_records = cls.graph().get_main_table_count()
 
         for main_table, main_table_records_count in main_models_records.items():
             metrics.graphdb_total_main_records.labels(main_table).set(main_table_records_count)
@@ -71,7 +71,7 @@ class DBMetrics(MetricsBase):
     @register_metric_job
     def get_tot_relation_records_count(cls) -> None:
         """Get the total number of Records for Relation Tables in Thoth Knowledge Graph."""
-        relation_models_records = cls.GRAPH.get_relation_table_count()
+        relation_models_records = cls.graph().get_relation_table_count()
 
         for relation_table, relation_table_records_count in relation_models_records.items():
             metrics.graphdb_total_relation_records.labels(relation_table).set(relation_table_records_count)
@@ -83,7 +83,7 @@ class DBMetrics(MetricsBase):
     def get_is_schema_up2date(cls) -> None:
         """Check if the schema running on metrics-exporter is same as the schema present in the database."""
         try:
-            metrics.graphdb_is_schema_up2date.set(int(cls.GRAPH.is_schema_up2date()))
+            metrics.graphdb_is_schema_up2date.set(int(cls.graph().is_schema_up2date()))
         except DatabaseNotInitialized as exc:
             _LOGGER.warning("Database schema is not initialized yet: %s", str(exc))
             metrics.graphdb_is_schema_up2date.set(0)

--- a/thoth/metrics_exporter/jobs/inspection.py
+++ b/thoth/metrics_exporter/jobs/inspection.py
@@ -59,7 +59,7 @@ class InspectionMetrics(MetricsBase):
     @register_metric_job
     def get_inspection_python_software_stack_count(cls) -> None:
         """Get the total number of Inspection Python Software Stacks in Thoth Knowledge Graph."""
-        thoth_graphdb_total_inspection_software_stacks = cls.GRAPH.get_python_software_stack_count_all(
+        thoth_graphdb_total_inspection_software_stacks = cls.graph().get_python_software_stack_count_all(
             software_stack_type=SoftwareStackTypeEnum.INSPECTION.value
         )
         metrics.graphdb_inspection_software_stacks_records.set(thoth_graphdb_total_inspection_software_stacks)

--- a/thoth/metrics_exporter/jobs/package_analyzer.py
+++ b/thoth/metrics_exporter/jobs/package_analyzer.py
@@ -34,7 +34,7 @@ class PackageAnalyzerMetrics(MetricsBase):
     @register_metric_job
     def get_analyzed_python_packages_count(cls) -> None:
         """Get number of unanlyzed Python packages."""
-        count = cls.GRAPH.get_analyzed_python_package_versions_count_all()
+        count = cls.graph().get_analyzed_python_package_versions_count_all()
         metrics.graphdb_total_number_analyzed_python_packages.set(count)
         _LOGGER.debug("graphdb_total_number_analyzed_python_packages=%r", count)
 
@@ -42,7 +42,7 @@ class PackageAnalyzerMetrics(MetricsBase):
     @register_metric_job
     def get_analyzed_error_python_packages_count(cls) -> None:
         """Get number of unalyzed Python packages."""
-        count = cls.GRAPH.get_analyzed_error_python_package_versions_count_all()
+        count = cls.graph().get_analyzed_error_python_package_versions_count_all()
         metrics.graphdb_total_number_analyzed_error_python_packages.set(count)
         _LOGGER.debug("graphdb_total_number_analyzed_error_python_packages=%r", count)
 
@@ -50,6 +50,6 @@ class PackageAnalyzerMetrics(MetricsBase):
     @register_metric_job
     def get_unanalyzed_python_packages_count(cls) -> None:
         """Get number of unanlyzed Python packages."""
-        count = cls.GRAPH.get_unanalyzed_python_package_versions_count_all()
+        count = cls.graph().get_unanalyzed_python_package_versions_count_all()
         metrics.graphdb_total_number_unanalyzed_python_packages.set(count)
         _LOGGER.debug("graphdb_total_number_unanalyzed_python_packages=%r", count)

--- a/thoth/metrics_exporter/jobs/pi.py
+++ b/thoth/metrics_exporter/jobs/pi.py
@@ -34,12 +34,12 @@ class PIMetrics(MetricsBase):
     @register_metric_job
     def get_observations_count_per_framework(cls) -> None:
         """Get the total number of PI per framework in Thoth Knowledge Graph."""
-        ML_FRAMEWORKS = cls.GRAPH.get_ml_frameworks_all()
+        ML_FRAMEWORKS = cls.graph().get_ml_frameworks_all()
         thoth_number_of_pi_per_type = {}
 
         if ML_FRAMEWORKS:
             for framework in ML_FRAMEWORKS:
-                thoth_number_of_pi_per_type[framework] = cls.GRAPH.get_pi_count(framework=framework)
+                thoth_number_of_pi_per_type[framework] = cls.graph().get_pi_count(framework=framework)
 
                 for pi, pi_count in thoth_number_of_pi_per_type[framework].items():
                     metrics.graphdb_total_number_of_pi_per_framework.labels(framework, pi).set(pi_count)
@@ -53,7 +53,7 @@ class PIMetrics(MetricsBase):
     @register_metric_job
     def get_tot_performance_records_count(cls) -> None:
         """Get the total number of Records for Performance tables in Thoth Knowledge Graph."""
-        performance_models_records = cls.GRAPH.get_performance_table_count()
+        performance_models_records = cls.graph().get_performance_table_count()
 
         for performance_table, performance_table_records_count in performance_models_records.items():
             metrics.graphdb_total_performance_records.labels(performance_table).set(performance_table_records_count)

--- a/thoth/metrics_exporter/jobs/python.py
+++ b/thoth/metrics_exporter/jobs/python.py
@@ -34,7 +34,7 @@ class PythonPackagesMetrics(MetricsBase):
     @register_metric_job
     def get_python_packages_versions_count(cls) -> None:
         """Get the total number of Python packages versions in Thoth Knowledge Graph."""
-        number_python_package_versions = cls.GRAPH.get_python_package_versions_count_all()
+        number_python_package_versions = cls.graph().get_python_package_versions_count_all()
         metrics.graphdb_number_python_package_versions.set(number_python_package_versions)
         _LOGGER.debug("graphdb_number_python_package_versions=%r", number_python_package_versions)
 
@@ -42,7 +42,7 @@ class PythonPackagesMetrics(MetricsBase):
     @register_metric_job
     def get_number_python_index_urls(cls) -> None:
         """Get the total number of python indexes in Thoth Knowledge Graph."""
-        python_urls_count = len(cls.GRAPH.get_python_package_index_urls_all())
+        python_urls_count = len(cls.graph().get_python_package_index_urls_all())
         metrics.graphdb_total_python_indexes.set(python_urls_count)
         _LOGGER.debug("thoth_graphdb_total_python_indexes=%r", python_urls_count)
 
@@ -50,11 +50,11 @@ class PythonPackagesMetrics(MetricsBase):
     @register_metric_job
     def get_python_packages_per_index_urls_count(cls) -> None:
         """Get the total number of unique python packages per index URL in Thoth Knowledge Graph."""
-        python_urls_list = list(cls.GRAPH.get_python_package_index_urls_all())
+        python_urls_list = list(cls.graph().get_python_package_index_urls_all())
         tot_packages = 0
         for index_url in python_urls_list:
 
-            packages_count = len(cls.GRAPH.get_python_package_versions_per_index(index_url=index_url)[index_url])
+            packages_count = len(cls.graph().get_python_package_versions_per_index(index_url=index_url)[index_url])
             tot_packages += packages_count
 
             metrics.graphdb_total_python_packages_per_indexes.labels(index_url).set(packages_count)

--- a/thoth/metrics_exporter/jobs/software_environment.py
+++ b/thoth/metrics_exporter/jobs/software_environment.py
@@ -34,7 +34,7 @@ class SoftwareEnvironmentMetrics(MetricsBase):
     @register_metric_job
     def get_unique_run_software_environment_count(cls) -> None:
         """Get the total number of unique software environment for run in Thoth Knowledge Graph."""
-        thoth_graphdb_total_run_software_environment = len(set(cls.GRAPH.get_run_software_environment_all()))
+        thoth_graphdb_total_run_software_environment = len(set(cls.graph().get_run_software_environment_all()))
         metrics.graphdb_total_run_software_environment.set(thoth_graphdb_total_run_software_environment)
         _LOGGER.debug("graphdb_total_unique_run_software_environment=%r", thoth_graphdb_total_run_software_environment)
 
@@ -42,7 +42,7 @@ class SoftwareEnvironmentMetrics(MetricsBase):
     @register_metric_job
     def get_unique_build_software_environment_count(cls) -> None:
         """Get the total number of unique software environment for build in Thoth Knowledge Graph."""
-        thoth_graphdb_total_build_software_environment = len(set(cls.GRAPH.get_build_software_environment_all()))
+        thoth_graphdb_total_build_software_environment = len(set(cls.graph().get_build_software_environment_all()))
 
         metrics.graphdb_total_build_software_environment.set(thoth_graphdb_total_build_software_environment)
         _LOGGER.debug(

--- a/thoth/metrics_exporter/jobs/solver.py
+++ b/thoth/metrics_exporter/jobs/solver.py
@@ -47,9 +47,9 @@ class SolverMetrics(MetricsBase):
     def get_unsolved_python_packages_count(cls) -> None:
         """Get number of unsolved Python packages per solver."""
         for solver_name in cls._OPENSHIFT.get_solver_names():
-            solver_info = cls.GRAPH.parse_python_solver_name(solver_name)
+            solver_info = cls.graph().parse_python_solver_name(solver_name)
 
-            count = cls.GRAPH.get_unsolved_python_package_versions_count_all(
+            count = cls.graph().get_unsolved_python_package_versions_count_all(
                 os_name=solver_info["os_name"],
                 os_version=solver_info["os_version"],
                 python_version=solver_info["python_version"],
@@ -62,13 +62,13 @@ class SolverMetrics(MetricsBase):
     @register_metric_job
     def get_python_packages_solver_error_count(cls) -> None:
         """Get the total number of python packages with solver error True and how many are unparsable or unsolvable."""
-        total_python_packages_solved = cls.GRAPH.get_solved_python_packages_count_all(distinct=True)
+        total_python_packages_solved = cls.graph().get_solved_python_packages_count_all(distinct=True)
 
-        total_python_packages_solver_error = cls.GRAPH.get_error_solved_python_package_versions_count_all(distinct=True)
-        total_python_packages_solver_error_unparseable = cls.GRAPH.get_error_solved_python_package_versions_count_all(
+        total_python_packages_solver_error = cls.graph().get_error_solved_python_package_versions_count_all(distinct=True)
+        total_python_packages_solver_error_unparseable = cls.graph().get_error_solved_python_package_versions_count_all(
             unparseable=True, distinct=True
         )
-        total_python_packages_solver_error_unsolvable = cls.GRAPH.get_error_solved_python_package_versions_count_all(
+        total_python_packages_solver_error_unsolvable = cls.graph().get_error_solved_python_package_versions_count_all(
             unsolvable=True, distinct=True
         )
 

--- a/thoth/metrics_exporter/jobs/user.py
+++ b/thoth/metrics_exporter/jobs/user.py
@@ -35,7 +35,7 @@ class UserInformationMetrics(MetricsBase):
     @register_metric_job
     def get_user_python_software_stack_count(cls) -> None:
         """Get the total number of User Python Software Stacks in Thoth Knowledge Graph."""
-        thoth_graphdb_total_software_stacks = cls.GRAPH.get_python_software_stack_count_all(
+        thoth_graphdb_total_software_stacks = cls.graph().get_python_software_stack_count_all(
             software_stack_type=SoftwareStackTypeEnum.USER.value
         )
         metrics.graphdb_user_software_stacks_records.set(thoth_graphdb_total_software_stacks)
@@ -46,7 +46,7 @@ class UserInformationMetrics(MetricsBase):
     def get_user_unique_run_software_environment_count(cls) -> None:
         """Get the total number of users unique software environment for run in Thoth Knowledge Graph."""
         thoth_graphdb_total_user_run_software_environment = len(
-            set(cls.GRAPH.get_run_software_environment_all(is_external=True))
+            set(cls.graph().get_run_software_environment_all(is_external=True))
         )
 
         metrics.graphdb_total_user_run_software_environment.set(thoth_graphdb_total_user_run_software_environment)


### PR DESCRIPTION
As we connected to graph before the actual fork of worker processes from
gunicorn master process, the connection pool was copied to multiple workers
(note we perform ping in the connection setup to verify correct connection
establishment so pool is not empty). This caused wrong connection handling on
worker processes which started using shared connection pool and unpredictable
errors in the deployment.