### PR TITLE
Introduce metric for number of solvers from database table

### DIFF
--- a/thoth/metrics_exporter/jobs/solver.py
+++ b/thoth/metrics_exporter/jobs/solver.py
@@ -39,12 +39,21 @@ class SolverMetrics(MetricsBase):
 
     @classmethod
     @register_metric_job
-    def get_solver_count(cls) -> None:
-        """Get number of solvers in Thoth Infra namespace."""
+    def get_solver_from_cm_count(cls) -> None:
+        """Get number of solvers from Thoth Solver ConfigMap."""
         solvers = len(cls._OPENSHIFT.get_solver_names())
 
         metrics.graphdb_total_number_solvers.set(solvers)
         _LOGGER.debug("graphdb_total_number_solvers=%r", solvers)
+
+    @classmethod
+    @register_metric_job
+    def get_solver_from_database_table_count(cls) -> None:
+        """Get number of solvers from database table."""
+        solvers = cls.graph().get_ecosystem_solver_count_all()
+
+        metrics.graphdb_total_number_solvers_database.set(solvers)
+        _LOGGER.debug("graphdb_total_number_solvers_database=%r", solvers)
 
     @classmethod
     @register_metric_job

--- a/thoth/metrics_exporter/metrics.py
+++ b/thoth/metrics_exporter/metrics.py
@@ -198,8 +198,12 @@ graphdb_total_number_si_not_analyzable_python_packages = Gauge(
 
 # SolverRun
 graphdb_total_number_solvers = Gauge(
-    "thoth_graphdb_total_number_solvers", "Total number of solvers in Thoth Infra namespace.", []
+    "thoth_graphdb_total_number_solvers", "Total number of solvers  of solvers from Thoth Solver ConfigMap.", []
 )
+graphdb_total_number_solvers_database = Gauge(
+    "thoth_graphdb_total_number_solvers_database", "Total number of solvers from database table.", []
+)
+
 graphdb_total_python_packages_solved_with_no_error = Gauge(
     "thoth_graphdb_total_python_packages_with_no_error",
     "Total number of python packages solved with no error.",


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Related-To: https://github.com/thoth-station/metrics-exporter/issues/586

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Introduce metrics on number of solvers identified from Ecosystem Solver database table

Metric for number of solvers from CM already exists and it is the default to verify number of packages solved per solver. 
