### PR TITLE
Add CVE metric

### DIFF
--- a/thoth/metrics_exporter/jobs/security.py
+++ b/thoth/metrics_exporter/jobs/security.py
@@ -83,3 +83,11 @@ class SecurityMetrics(MetricsBase):
         )
         metrics.graphdb_total_number_si_not_analyzable_python_packages.set(count_si_not_analyzable)
         _LOGGER.debug("graphdb_total_number_si_not_analyzable_python_packages=%r", count_si_not_analyzable)
+
+    @classmethod
+    @register_metric_job
+    def get_cve_count(cls) -> None:
+        """Get number of CVE in thoth database."""
+        count_cve = cls.graph().get_python_cve_records_count()
+        metrics.graphdb_total_number_cve.set(count_cve)
+        _LOGGER.debug("graphdb_total_number_cve=%r", count_cve)

--- a/thoth/metrics_exporter/metrics.py
+++ b/thoth/metrics_exporter/metrics.py
@@ -188,9 +188,7 @@ graphdb_si_unanalyzed_python_package_versions_change = Counter(
 graphdb_total_number_si_not_analyzable_python_packages = Gauge(
     "thoth_graphdb_total_number_si_not_analyzable_python_packages", "SI not analyzable Python package.", []
 )
-graphdb_total_number_cve  = Gauge(
-    "thoth_graphdb_total_number_cve", "Number of CVE in Thoth database.", []
-)
+graphdb_total_number_cve = Gauge("thoth_graphdb_total_number_cve", "Number of CVE in Thoth database.", [])
 
 # SolverRun
 graphdb_total_number_solvers = Gauge(

--- a/thoth/metrics_exporter/metrics.py
+++ b/thoth/metrics_exporter/metrics.py
@@ -188,7 +188,9 @@ graphdb_si_unanalyzed_python_package_versions_change = Counter(
 graphdb_total_number_si_not_analyzable_python_packages = Gauge(
     "thoth_graphdb_total_number_si_not_analyzable_python_packages", "SI not analyzable Python package.", []
 )
-
+graphdb_total_number_cve  = Gauge(
+    "thoth_graphdb_total_number_cve", "Number of CVE in Thoth database.", []
+)
 
 # SolverRun
 graphdb_total_number_solvers = Gauge(


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/metrics-exporter/issues/174

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Add metric on number of CVE.

## Description

```
# HELP thoth_graphdb_total_number_cve Number of CVE in Thoth database.
# TYPE thoth_graphdb_total_number_cve gauge thoth_graphdb_total_number_cve 430.0
```
