### PR TITLE
Introduce a metric for number of days since the last CVE update

### DIFF
--- a/thoth/metrics_exporter/jobs/security.py
+++ b/thoth/metrics_exporter/jobs/security.py
@@ -19,6 +19,7 @@
 
 import logging
 import os
+from datetime import datetime
 
 import thoth.metrics_exporter.metrics as metrics
 
@@ -91,3 +92,16 @@ class SecurityMetrics(MetricsBase):
         count_cve = cls.graph().get_python_cve_records_count()
         metrics.graphdb_total_number_cve.set(count_cve)
         _LOGGER.debug("graphdb_total_number_cve=%r", count_cve)
+
+    @classmethod
+    @register_metric_job
+    def get_cve_update_days(cls) -> None:
+        """Compute number of days since the last CVE update was done."""
+        cve_timestamp = cls.graph().get_cve_timestamp()
+        if cve_timestamp is None:
+            _LOGGER.error("No CVE timestamp set in the database")
+            return
+
+        days = (datetime.utcnow() - cve_timestamp).days
+        metrics.graphdb_cve_update_days.set(days)
+        _LOGGER.debug("graphdb_cve_update_days=%r", days)

--- a/thoth/metrics_exporter/metrics.py
+++ b/thoth/metrics_exporter/metrics.py
@@ -182,6 +182,7 @@ graphdb_total_number_si_not_analyzable_python_packages = Gauge(
     "thoth_graphdb_total_number_si_not_analyzable_python_packages", "SI not analyzable Python package.", []
 )
 graphdb_total_number_cve = Gauge("thoth_graphdb_total_number_cve", "Number of CVE in Thoth database.", [])
+graphdb_cve_update_days = Gauge("thoth_graphdb_cve_update_days", "days since last cve-update was done", [])
 
 # SolverRun
 graphdb_total_number_solvers = Gauge(


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/storages/pull/2460
Related: https://github.com/thoth-station/adviser/issues/2142

## This introduces a breaking change

- [x] No

## Description

With this information, we will be able to see when CVEs from PyPA/advisory-db were last updated.
