### PR TITLE
Register metric to get datetime of last solver synced in database

### DIFF
--- a/thoth/metrics_exporter/jobs/db.py
+++ b/thoth/metrics_exporter/jobs/db.py
@@ -135,4 +135,4 @@ class DBMetrics(MetricsBase):
         last_solver_datetime = cls.graph().get_last_solver_datetime(
             os_name=os_name, os_version=os_version, python_version=python_version
         )
-        metrics.graphdb_last_solver_datetime.labels(format_datetime(last_solver_datetime)).inc()
+        metrics.graphdb_last_solver_datetime.labels(format_datetime(last_solver_datetime)).set(1)

--- a/thoth/metrics_exporter/jobs/db.py
+++ b/thoth/metrics_exporter/jobs/db.py
@@ -19,6 +19,7 @@
 
 import logging
 import time
+from typing import Optional
 
 import thoth.metrics_exporter.metrics as metrics
 
@@ -127,7 +128,11 @@ class DBMetrics(MetricsBase):
 
     @classmethod
     @register_metric_job
-    def set_last_solver_datetime(cls) -> None:
+    def set_last_solver_datetime(
+        cls, os_name: Optional[str] = None, os_version: Optional[str] = None, python_version: Optional[str] = None
+    ) -> None:
         """Get datetime of the last solver synced in the database."""
-        last_solver_datetime = cls.graph().get_last_solver_datetime()
+        last_solver_datetime = cls.graph().get_last_solver_datetime(
+            os_name=os_name, os_version=os_version, python_version=python_version
+        )
         metrics.graphdb_last_solver_datetime.set(time.mktime(last_solver_datetime.timetuple()))

--- a/thoth/metrics_exporter/jobs/db.py
+++ b/thoth/metrics_exporter/jobs/db.py
@@ -25,7 +25,7 @@ import thoth.metrics_exporter.metrics as metrics
 from .base import register_metric_job
 from .base import MetricsBase
 from ..configuration import Configuration
-from thoth.common import format_datetime
+from thoth.common.helpers import format_datetime
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/thoth/metrics_exporter/jobs/db.py
+++ b/thoth/metrics_exporter/jobs/db.py
@@ -18,7 +18,6 @@
 """Knowledge graph metrics."""
 
 import logging
-import time
 from typing import Optional
 
 import thoth.metrics_exporter.metrics as metrics
@@ -26,6 +25,7 @@ import thoth.metrics_exporter.metrics as metrics
 from .base import register_metric_job
 from .base import MetricsBase
 from ..configuration import Configuration
+from thoth.common import format_datetime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -135,4 +135,4 @@ class DBMetrics(MetricsBase):
         last_solver_datetime = cls.graph().get_last_solver_datetime(
             os_name=os_name, os_version=os_version, python_version=python_version
         )
-        metrics.graphdb_last_solver_datetime.set(time.mktime(last_solver_datetime.timetuple()))
+        metrics.graphdb_last_solver_datetime.set(format_datetime(last_solver_datetime))

--- a/thoth/metrics_exporter/jobs/db.py
+++ b/thoth/metrics_exporter/jobs/db.py
@@ -135,4 +135,4 @@ class DBMetrics(MetricsBase):
         last_solver_datetime = cls.graph().get_last_solver_datetime(
             os_name=os_name, os_version=os_version, python_version=python_version
         )
-        metrics.graphdb_last_solver_datetime.set(format_datetime(last_solver_datetime))
+        metrics.graphdb_last_solver_datetime.labels(format_datetime(last_solver_datetime)).inc()

--- a/thoth/metrics_exporter/jobs/db.py
+++ b/thoth/metrics_exporter/jobs/db.py
@@ -18,6 +18,7 @@
 """Knowledge graph metrics."""
 
 import logging
+import time
 
 import thoth.metrics_exporter.metrics as metrics
 
@@ -123,3 +124,10 @@ class DBMetrics(MetricsBase):
             else:
                 # component is using same revision head as in the database
                 metrics.graph_db_component_revision_check.labels(component_name, Configuration.DEPLOYMENT_NAME).set(0)
+
+    @classmethod
+    @register_metric_job
+    def set_last_solver_datetime(cls) -> None:
+        """Get datetime of the last solver synced in the database."""
+        last_solver_datetime = cls.graph().get_last_solver_datetime()
+        metrics.graphdb_last_solver_datetime.set(time.mktime(last_solver_datetime.timetuple()))

--- a/thoth/metrics_exporter/metrics.py
+++ b/thoth/metrics_exporter/metrics.py
@@ -98,6 +98,9 @@ graphdb_alembic_version_rows = Gauge(
 
 graphdb_alembic_table_check = Gauge("thoth_graphdb_alembic_table_check", "alembic version table rows check.", [])
 
+graphdb_last_solver_datetime = Gauge(
+    "thoth_graphdb_last_solver_datetime", "Datetime of the last solver synced in the database.", []
+)
 
 # CONTENT METRICS
 

--- a/thoth/metrics_exporter/metrics.py
+++ b/thoth/metrics_exporter/metrics.py
@@ -99,7 +99,7 @@ graphdb_alembic_version_rows = Gauge(
 graphdb_alembic_table_check = Gauge("thoth_graphdb_alembic_table_check", "alembic version table rows check.", [])
 
 graphdb_last_solver_datetime = Gauge(
-    "thoth_graphdb_last_solver_datetime", "Datetime of the last solver synced in the database.", []
+    "thoth_graphdb_last_solver_datetime", "Datetime of the last solver synced in the database.", ["datetime"]
 )
 
 # CONTENT METRICS


### PR DESCRIPTION
## Related Issues and Dependencies

Related to #822 

## This introduces a breaking change

- No

## This Pull Request implements

Register a metric to get the datetime of the last solver run synced in the database