### PR TITLE
Register metric for datetime of last container image analysis synced in the database

### DIFF
--- a/thoth/metrics_exporter/jobs/db.py
+++ b/thoth/metrics_exporter/jobs/db.py
@@ -130,4 +130,4 @@ class DBMetrics(MetricsBase):
     def set_last_analysis_datetime(cls) -> None:
         """Get datetime of the last container image synced in the database."""
         last_analysis_datetime = cls.graph().get_last_analysis_datetime()
-        metrics.graphdb_last_analysis_datetime.set(format_datetime(last_analysis_datetime))
+        metrics.graphdb_last_analysis_datetime.labels(format_datetime(last_analysis_datetime)).inc()

--- a/thoth/metrics_exporter/jobs/db.py
+++ b/thoth/metrics_exporter/jobs/db.py
@@ -130,4 +130,4 @@ class DBMetrics(MetricsBase):
     def set_last_analysis_datetime(cls) -> None:
         """Get datetime of the last container image synced in the database."""
         last_analysis_datetime = cls.graph().get_last_analysis_datetime()
-        metrics.graphdb_last_analysis_datetime.labels(format_datetime(last_analysis_datetime)).inc()
+        metrics.graphdb_last_analysis_datetime.labels(format_datetime(last_analysis_datetime)).set(1)

--- a/thoth/metrics_exporter/jobs/db.py
+++ b/thoth/metrics_exporter/jobs/db.py
@@ -24,7 +24,7 @@ import thoth.metrics_exporter.metrics as metrics
 from .base import register_metric_job
 from .base import MetricsBase
 from ..configuration import Configuration
-from thoth.common import format_datetime
+from thoth.common.helpers import format_datetime
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/thoth/metrics_exporter/jobs/db.py
+++ b/thoth/metrics_exporter/jobs/db.py
@@ -129,5 +129,5 @@ class DBMetrics(MetricsBase):
     @register_metric_job
     def set_last_image_datetime(cls) -> None:
         """Get datetime of the last container image synced in the database."""
-        last_image_datetime = cls.graph().get_last_image_datetime()
+        last_image_datetime = cls.graph().get_last_analysis_datetime()
         metrics.graphdb_last_image_datetime.set(format_datetime(last_image_datetime))

--- a/thoth/metrics_exporter/jobs/db.py
+++ b/thoth/metrics_exporter/jobs/db.py
@@ -18,13 +18,13 @@
 """Knowledge graph metrics."""
 
 import logging
-import time
 
 import thoth.metrics_exporter.metrics as metrics
 
 from .base import register_metric_job
 from .base import MetricsBase
 from ..configuration import Configuration
+from thoth.common import format_datetime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -130,4 +130,4 @@ class DBMetrics(MetricsBase):
     def set_last_image_datetime(cls) -> None:
         """Get datetime of the last container image synced in the database."""
         last_image_datetime = cls.graph().get_last_image_datetime()
-        metrics.graphdb_last_image_datetime.set(time.mktime(last_image_datetime.timetuple()))
+        metrics.graphdb_last_image_datetime.set(format_datetime(last_image_datetime))

--- a/thoth/metrics_exporter/jobs/db.py
+++ b/thoth/metrics_exporter/jobs/db.py
@@ -18,6 +18,7 @@
 """Knowledge graph metrics."""
 
 import logging
+import time
 
 import thoth.metrics_exporter.metrics as metrics
 
@@ -123,3 +124,10 @@ class DBMetrics(MetricsBase):
             else:
                 # component is using same revision head as in the database
                 metrics.graph_db_component_revision_check.labels(component_name, Configuration.DEPLOYMENT_NAME).set(0)
+
+    @classmethod
+    @register_metric_job
+    def set_last_image_datetime(cls) -> None:
+        """Get datetime of the last container image synced in the database."""
+        last_image_datetime = cls.graph().get_last_image_datetime()
+        metrics.graphdb_last_image_datetime.set(time.mktime(last_image_datetime.timetuple()))

--- a/thoth/metrics_exporter/jobs/db.py
+++ b/thoth/metrics_exporter/jobs/db.py
@@ -127,7 +127,7 @@ class DBMetrics(MetricsBase):
 
     @classmethod
     @register_metric_job
-    def set_last_image_datetime(cls) -> None:
+    def set_last_analysis_datetime(cls) -> None:
         """Get datetime of the last container image synced in the database."""
-        last_image_datetime = cls.graph().get_last_analysis_datetime()
-        metrics.graphdb_last_image_datetime.set(format_datetime(last_image_datetime))
+        last_analysis_datetime = cls.graph().get_last_analysis_datetime()
+        metrics.graphdb_last_analysis_datetime.set(format_datetime(last_analysis_datetime))

--- a/thoth/metrics_exporter/metrics.py
+++ b/thoth/metrics_exporter/metrics.py
@@ -99,7 +99,9 @@ graphdb_alembic_version_rows = Gauge(
 graphdb_alembic_table_check = Gauge("thoth_graphdb_alembic_table_check", "alembic version table rows check.", [])
 
 graphdb_last_analysis_datetime = Gauge(
-    "thoth_graphdb_last_analysis_datetime", "Datetime of the last container image analysis synced in the database.", []
+    "thoth_graphdb_last_analysis_datetime",
+    "Datetime of the last container image analysis synced in the database.",
+    ["datetime"],
 )
 
 # CONTENT METRICS

--- a/thoth/metrics_exporter/metrics.py
+++ b/thoth/metrics_exporter/metrics.py
@@ -98,8 +98,8 @@ graphdb_alembic_version_rows = Gauge(
 
 graphdb_alembic_table_check = Gauge("thoth_graphdb_alembic_table_check", "alembic version table rows check.", [])
 
-graphdb_last_image_datetime = Gauge(
-    "thoth_graphdb_last_image_datetime", "Datetime of the last container image analysis synced in the database.", []
+graphdb_last_analysis_datetime = Gauge(
+    "thoth_graphdb_last_analysis_datetime", "Datetime of the last container image analysis synced in the database.", []
 )
 
 # CONTENT METRICS

--- a/thoth/metrics_exporter/metrics.py
+++ b/thoth/metrics_exporter/metrics.py
@@ -98,6 +98,9 @@ graphdb_alembic_version_rows = Gauge(
 
 graphdb_alembic_table_check = Gauge("thoth_graphdb_alembic_table_check", "alembic version table rows check.", [])
 
+graphdb_last_image_datetime = Gauge(
+    "thoth_graphdb_last_image_datetime", "Datetime of the last container image analysis synced in the database.", []
+)
 
 # CONTENT METRICS
 


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/metrics-exporter/issues/822
- [ ] optionally, we can do the same for container image analyses to see if we have containerized environments properly analyzed and synced

Depends on https://github.com/thoth-station/storages/pull/2592

## This introduces a breaking change

-  No

## This Pull Request implements

Register a metric to get the datetime of the last container image analysis synced in the database. Can require changes if we choose to filter the container images in https://github.com/thoth-station/storages/pull/2592
