### PR TITLE
Update GitHub templates and pre-commit plugin versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,24 +1,27 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: kind/bug, triage/needs-information
+labels: kind/bug
 ---
+## Bug description
+<!-- A clear and concise description of what the bug is. -->
 
-**Describe the bug**
-A clear and concise description of what the bug is.
-
-**To Reproduce**
+### Steps to Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+### Actual behavior
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Additional context**
-Add any other context about the problem here.
+### Environment information
+<!-- Please include names and versions of the components involved.
+If appropriate, include relevant parts of their configuration. -->
+
+### Additional context
+<!-- Add any additional context information about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,17 +1,31 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: kind/feature, triage/needs-information
+labels: kind/feature
 ---
+## Problem statement
+<!-- Is your feature request related to a problem? Please provide a clear and concise description of what the problem is.
+Ex. I'm always frustrated when [...]
+This should be a user story! -->
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## High-level Goals
+<!-- list of high-level Acceptance Criteria/Goals (that is signed off by the team, and unchangeable) -->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+## Proposal description
+<!-- Describe the solution you'd like.
+A clear and concise description of what you want to happen. -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+### Alternatives
+<!-- Describe alternatives you've considered.
+A clear and concise description of any alternative solutions or features you've considered. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+### Additional context
+<!-- Add any other context or screenshots about the feature request here. -->
+
+## Acceptance Criteria
+<!-- checklist of detailed Acceptance Criteria (that might extend over the lifetime of the card).
+Use checkboxes to track each item. -->
+
+- [ ] example
+
+<!-- If applicable add a measure of complexity (story points)/time estimate to the title using [...pt] -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,25 @@
 ## Related Issues and Dependencies
-
-…
+<!-- Mention any relevant issue/PR here.
+In particular, if this PR resolves issue XYZ, make sure you add a line:
+Fixes: #XYZ -->
 
 ## This introduces a breaking change
+<!-- Leave one of the options -->
 
-- [ ] Yes
-- [ ] No
+- Yes
+- No
 
 <!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
 
 ## This should yield a new module release
 
-- [ ] Yes
-- [ ] No
+- Yes
+- No
+
+<!-- If this change modifies the behavior of the module, specify that it should yield a new minor release. -->
 
 ## This Pull Request implements
+<!-- Provide a summary of your changes here. -->
 
-… Explain your changes.
-
-## Description
-
-<!--- Describe your changes in detail -->
+### Description
+<!--- Describe your changes in detail here. -->

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,38 +2,32 @@
 ---
 repos:
   - repo: git://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.9
+    rev: v1.1.12
     hooks:
       - id: remove-tabs
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.1.0
     hooks:
-      - id: trailing-whitespace
-      - id: check-merge-conflict
-      - id: end-of-file-fixer
       - id: check-added-large-files
+      - id: check-ast
       - id: check-byte-order-marker
       - id: check-case-conflict
       - id: check-docstring-first
       - id: check-json
+      - id: check-merge-conflict
       - id: check-symlinks
-      - id: detect-private-key
-      - id: check-ast
-      - id: debug-statements
-
-  - repo: git://github.com/pycqa/pydocstyle.git
-    rev: 5.1.1
-    hooks:
-      - id: pydocstyle
-
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
-    hooks:
       - id: check-toml
       - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
       - id: end-of-file-fixer
       - id: trailing-whitespace
+
+  - repo: git://github.com/pycqa/pydocstyle.git
+    rev: 6.1.1
+    hooks:
+      - id: pydocstyle
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.812
@@ -44,12 +38,12 @@ repos:
         additional_dependencies: [attrs~=19.3]
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.1.0
     hooks:
       - id: black
 
   - repo: https://gitlab.com/PyCQA/flake8
-    rev: '3.8.4'
+    rev: '3.9.2'
     hooks:
       - id: flake8
         additional_dependencies: ['pep8-naming']

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -6,7 +6,7 @@ presubmits:
     context: aicoe-ci/prow/pre-commit
     spec:
       containers:
-        - image: quay.io/thoth-station/thoth-precommit-py38:v0.12.5
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.14.3
           command:
             - "pre-commit"
             - "run"


### PR DESCRIPTION
## This Pull Request implements

Update the GitHub issue templates using the ones from the template project.

## Description

<!--- Describe your changes in detail -->

The main need here was to switch the default issue label to `needs-triage` instead of `triage/needs-information` (the latter is to be added after a review that detects missing information), and the removal of the Yes/No check-box style from #840.

Also taking the opportunity to update pre-commit plugins